### PR TITLE
Prevent usage of poetry>2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "yato-lib"
-version = "0.0.15"
+version = "0.0.16"
 authors = ["Christophe Blefari <yato@blef.fr>"]
 license = "MIT"
 description = "The smallest DuckDB SQL transformations orchestrator"
@@ -40,7 +40,7 @@ line-length = 120
 line_length = 120
 profile = "black"
 [build-system]
-requires = ["poetry-core>=1.0.8"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"
 [project.urls]
 Homepage = "https://github.com/Bl3f/yato"


### PR DESCRIPTION
Temporarily fixes #9. By preventing usage of poetry>2.0.0 until I find how to make it compatible.