### PR TITLE
Duckdb UI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,38 @@
+import shlex
+
+from click.testing import CliRunner
+import pytest
+from yato.cli import run
+
+runner = CliRunner()
+
+
+def yato_cli(command_string):
+    """Helper function to run the CLI with a command string."""
+    command_list = shlex.split(command_string)
+    result = runner.invoke(run, command_list)
+    return result.stdout.rstrip()
+
+
+@pytest.mark.parametrize(
+    "command_string, expected_message_part",
+    [
+        ("", "Usage:"),
+        ("--help", "Usage:"),
+        ("tests/files/case0", "Running 3 objects..."),
+        ("--db mock.duckdb --schema transform tests/files", "Running 6 objects..."),
+    ],
+)
+def test_yato_cli_run(command_string, expected_message_part):
+    """Test the yato CLI run command."""
+    result = yato_cli(command_string)
+    assert result is not None
+    assert expected_message_part in result, f"Expected '{expected_message_part}' in the output, but got: {result}"
+
+def test_yato_cli_run_ui_enabled(monkeypatch):
+    """Test the yato CLI run command with UI option."""
+    # Mock the console to avoid actual UI interaction
+    monkeypatch.setattr("duckdb.__version__", "1.2.0")  # Ensure the version is compatible
+    result = yato_cli("--ui tests/files/case0")
+    assert "DuckDB UI requires version >= 1.2.1." in result
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,8 @@
 import shlex
 
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
+
 from yato.cli import run
 
 runner = CliRunner()
@@ -29,10 +30,10 @@ def test_yato_cli_run(command_string, expected_message_part):
     assert result is not None
     assert expected_message_part in result, f"Expected '{expected_message_part}' in the output, but got: {result}"
 
+
 def test_yato_cli_run_ui_enabled(monkeypatch):
     """Test the yato CLI run command with UI option."""
     # Mock the console to avoid actual UI interaction
     monkeypatch.setattr("duckdb.__version__", "1.2.0")  # Ensure the version is compatible
     result = yato_cli("--ui tests/files/case0")
     assert "DuckDB UI requires version >= 1.2.1." in result
-

--- a/yato/cli.py
+++ b/yato/cli.py
@@ -1,7 +1,7 @@
 import click
 
 from yato import Yato
-
+import duckdb
 
 @click.group()
 def cli():
@@ -12,7 +12,8 @@ def cli():
 @click.argument("sql")
 @click.option("--db", help="Path to the DuckDB database.", default="yato.duckdb", show_default=True)
 @click.option("--schema", help="The schema to use in the DuckDB database.", default="transform")
-def run(sql, db, schema):
+@click.option("--ui", help="Open the local DuckDB UI upon run completion (requires DuckDB >= v1.2.1)", is_flag=True, default=False, show_default=True)
+def run(sql, db, schema, ui):
     """
     Run yato against a DuckDB database using the SQL files.
 
@@ -24,8 +25,23 @@ def run(sql, db, schema):
         schema=schema,
     )
 
-    yato.run()
+    try:
+        con, context = yato.run()
+    except Exception as err:
+        raise err
 
+    if duckdb.__version__ >= "1.2.1":
+        if ui:
+            with context.console.status("[bold green]Started DuckDB UI. Press CTRL+C to exit..."):
+                context.sql("call start_ui()")
+                try:
+                    while True:
+                        pass
+                except KeyboardInterrupt:
+                    pass
+    else:
+        if ui:
+            context.console.print("[bold yellow]DuckDB UI requires version >= 1.2.1. Please update DuckDB to use this feature.")
 
 if __name__ == "__main__":
     cli()

--- a/yato/cli.py
+++ b/yato/cli.py
@@ -1,7 +1,8 @@
 import click
+import duckdb
 
 from yato import Yato
-import duckdb
+
 
 @click.group()
 def cli():
@@ -12,7 +13,13 @@ def cli():
 @click.argument("sql")
 @click.option("--db", help="Path to the DuckDB database.", default="yato.duckdb", show_default=True)
 @click.option("--schema", help="The schema to use in the DuckDB database.", default="transform")
-@click.option("--ui", help="Open the local DuckDB UI upon run completion (requires DuckDB >= v1.2.1)", is_flag=True, default=False, show_default=True)
+@click.option(
+    "--ui",
+    help="Open the local DuckDB UI upon run completion (requires DuckDB >= v1.2.1)",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
 def run(sql, db, schema, ui):
     """
     Run yato against a DuckDB database using the SQL files.
@@ -41,7 +48,10 @@ def run(sql, db, schema, ui):
                     pass
     else:
         if ui:
-            context.console.print("[bold yellow]DuckDB UI requires version >= 1.2.1. Please update DuckDB to use this feature.")
+            context.console.print(
+                "[bold yellow]DuckDB UI requires version >= 1.2.1. Please update DuckDB to use this feature."
+            )
+
 
 if __name__ == "__main__":
     cli()

--- a/yato/yato.py
+++ b/yato/yato.py
@@ -211,4 +211,4 @@ class Yato:
         self.run_pre_queries(context)
         self.run_objects(execution_order, dependencies, context)
         generate_mermaid_diagram(self.sql_folder, dependencies)
-        return con
+        return con, context


### PR DESCRIPTION
This PR would close #14.

* [`yato/yato.py`](diffhunk://#diff-e8d59cbd751da3544f3c840b0206018f9cb4a497ac2e47f514a06575e1eeabeaL214-R214): Updated the `run` method to return both `con` and `context` objects to support the new UI functionality.
* [`yato/cli.py`](diffhunk://#diff-c36fc882d33640df98920e57702fb9d63e936f0a50e2825b40130cfa9317c9c0L15-R16): Added an option `--ui` to the `run` command to open the local DuckDB UI upon run completion, provided DuckDB version is 1.2.1 or higher. Imported the `duckdb` module to facilitate version checks and UI interactions.
* [`tests/test_cli.py`](diffhunk://#diff-4e8715c7a425ee52e74b7df4d34efd32e8c92f3e60bd51bc2e1ad5943b82032eR1-R38): Started tests for the CLI module.