### PR TITLE
fix(test): use 'output' to capture stderr from CLI errors

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def yato_cli(command_string):
     """Helper function to run the CLI with a command string."""
     command_list = shlex.split(command_string)
     result = runner.invoke(run, command_list)
-    return result.stdout.rstrip()
+    return result.output.rstrip()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Fix CLI tests to properly capture error messages by using `result.output` instead of `result.stdout`.

## Context
Click's `CliRunner` mixes stderr into the `output` property by default. Error messages (like missing required arguments) go to stderr, so they weren't being captured by `stdout`.

<details><summary>`pytest` before fix</summary>
<img width="1290" height="690" alt="Screenshot 2025-11-10 at 11 45 29" src="https://github.com/user-attachments/assets/94c352aa-a2fa-4826-a6d4-8098654de7d5" />
</details>

<details><summary>`pytest` after fix</summary>
<img width="1299" height="227" alt="Screenshot 2025-11-10 at 11 45 05" src="https://github.com/user-attachments/assets/5faef0d5-abb9-493b-9d28-8acf9fdd3159" />
</details>