### PR TITLE
chore(git): ignore mermaid diagrams generated during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 .DS_Store
 
 *.duckdb
+
+# Ignore mermaid diagrams generated during tests
+tests/**/*.mmd


### PR DESCRIPTION
## Problem
Running tests generates a `tests/files/case0/lineage.mmd` file as a side effect of the full yato pipeline execution. This file pollute version control.

## Solution
Add `tests/**/*.mmd` pattern to `.gitignore` to ignore mermaid diagrams generated in test directories.